### PR TITLE
schwierigen Modus hinzufügen

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@
             </label>
         </div>
         <div class="control">
+            <label title="Die Vorder- und Rückseite der Münze zusammenfinden.">
+                <input class="difficult" type="checkbox">
+                schwierig
+            </label>
+        </div>
+        <div class="control">
             <p class="moves"></p>
         </div>
     </div>


### PR DESCRIPTION
Wird durch eine Checkbox aktiviert und führt dazu,
dass Vorder- und Rückseite der Münze angezeigt
werden und als zusammengehörig erkannt werden
müssen.
